### PR TITLE
[FEAT]: Exclude files from being registered/published

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ for me.
 ## Installation and usage
 
 Just run the command: 
+
 ```shell
 composer require asciito/laravel-package
 ```
@@ -60,11 +61,6 @@ class LaravelPackageServiceProvider extends PackageServiceProvider
     protected function configurePackage(Package $package): void
     {
         $package->setName('<your-package-name>');
-    }
-
-    protected function getNamespace(): string
-    {
-        return __NAMESPACE__;
     }
 }
 ```

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -14,6 +14,7 @@
     </testsuites>
     <php>
         <env name="DB_CONNECTION" value="testing"/>
+        <env name="DB_DATABASE" value=":memory:"/>
         <env name="RAY_ENABLED" value="(true)"/>
         <env name="SEND_CACHE_TO_RAY" value="(false)"/>
         <env name="SEND_DUMPS_TO_RAY" value="(true)"/>

--- a/src/Package/Concerns/HasCommands.php
+++ b/src/Package/Concerns/HasCommands.php
@@ -23,7 +23,7 @@ trait HasCommands
 
     private function shouldLoadDefaultCommandsFolder(): bool
     {
-        return !$this->preventLoadDefaultCommandsFolder && $this->shouldLoadCommandsFromDefaultFolder;
+        return ! $this->preventLoadDefaultCommandsFolder && $this->shouldLoadCommandsFromDefaultFolder;
     }
 
     public function preventDefaultCommands(): static
@@ -57,7 +57,7 @@ trait HasCommands
 
         return collect($this->commands)
             ->merge($commands)
-            ->filter(fn (string $command) => !in_array($command, $this->excludedCommands));
+            ->filter(fn (string $command) => ! in_array($command, $this->excludedCommands));
     }
 
     public function loadCommandsFromDefaultFolder()
@@ -68,7 +68,7 @@ trait HasCommands
                 ->after('Console/')
                 ->replace('/', '\\')
                 ->remove('.php')
-                ->prepend($this->getNamespace() . '\\Console\\')
+                ->prepend($this->getNamespace().'\\Console\\')
                 ->toString()
             )
             ->all();

--- a/src/Package/Concerns/HasConfig.php
+++ b/src/Package/Concerns/HasConfig.php
@@ -25,7 +25,7 @@ trait HasConfig
 
     private function shouldLoadDefaultConfigFolder(): bool
     {
-        return !$this->preventLoadDefaultConfigFolder && $this->shouldIncludeConfigFromFolder;
+        return ! $this->preventLoadDefaultConfigFolder && $this->shouldIncludeConfigFromFolder;
     }
 
     public function withConfig(string|array $config = [], bool $publish = true): static
@@ -56,14 +56,14 @@ trait HasConfig
         return collect($this->configFiles)
             ->merge($config)
             ->filter(function (bool $_, string $config) {
-                return !in_array($config, $this->excludedConfig);
+                return ! in_array($config, $this->excludedConfig);
             })
             ->keys();
     }
 
     private function loadConfigDefaultFolder(): array
     {
-        if (!$this->shouldLoadDefaultConfigFolder()) {
+        if (! $this->shouldLoadDefaultConfigFolder()) {
             return [];
         }
 
@@ -89,7 +89,7 @@ trait HasConfig
         return collect($this->configFiles)
             ->merge($config)
             ->filter(function (bool $publish, string $config) {
-                return $publish && !in_array($config, [...$this->excludedConfig, ...$this->unpublishedConfig]);
+                return $publish && ! in_array($config, [...$this->excludedConfig, ...$this->unpublishedConfig]);
             })
             ->keys();
     }

--- a/src/Package/Concerns/HasConfig.php
+++ b/src/Package/Concerns/HasConfig.php
@@ -3,8 +3,6 @@
 namespace Asciito\LaravelPackage\Package\Concerns;
 
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\File;
-use Symfony\Component\Finder\SplFileInfo;
 
 trait HasConfig
 {
@@ -60,7 +58,7 @@ trait HasConfig
     {
         $config = $this->loadConfigDefaultFolder();
 
-         return collect($this->configFiles)
+        return collect($this->configFiles)
             ->merge($config)
             ->filter(function (bool $publish, string $config) {
                 return $publish && ! in_array($config, [...$this->excludedConfig, ...$this->unpublishedConfig]);

--- a/src/Package/Concerns/HasConfig.php
+++ b/src/Package/Concerns/HasConfig.php
@@ -55,7 +55,7 @@ trait HasConfig
         $register = collect($this->configFiles)
             ->merge($config)
             ->filter(function (bool $_, string $config) {
-                return ! in_array($this->getConfigName($config), $this->excludedConfig);
+                return ! in_array($this->getFileName($config), $this->excludedConfig);
             })
             ->keys();
 
@@ -73,7 +73,7 @@ trait HasConfig
         $publish = collect($this->configFiles)
             ->merge($config)
             ->filter(function (bool $publish, string $config) {
-                return $publish && ! in_array($this->getConfigName($config), [...$this->excludedConfig, ...$this->unpublishedConfig]);
+                return $publish && ! in_array($this->getFileName($config), [...$this->excludedConfig, ...$this->unpublishedConfig]);
             })
             ->keys();
 
@@ -94,14 +94,14 @@ trait HasConfig
 
     public function unregisterConfig(string $path): static
     {
-        $this->excludedConfig[] = $this->getConfigName($path);
+        $this->excludedConfig[] = $this->getFileName($path);
 
         return $this;
     }
 
     public function unpublishConfig(string $path): static
     {
-        $this->unpublishedConfig[] = $this->getConfigName($path);
+        $this->unpublishedConfig[] = $this->getFileName($path);
 
         return $this;
     }
@@ -119,10 +119,5 @@ trait HasConfig
             ->filter(fn (SplFileInfo $file) => $file->getExtension() === 'php')
             ->mapWithKeys(fn (SplFileInfo $file) => [(string) $file => true])
             ->all();
-    }
-
-    private function getConfigName(string $file): string
-    {
-        return str_replace('.php', '', basename($file));
     }
 }

--- a/src/Package/Concerns/HasMigrations.php
+++ b/src/Package/Concerns/HasMigrations.php
@@ -114,7 +114,6 @@ trait HasMigrations
         return $this;
     }
 
-
     private function shouldLoadDefaultMigrationsFolder(): bool
     {
         return ! $this->preventLoadDefault && $this->shouldIncludeMigrationsFromFolder;

--- a/src/Package/Concerns/HasMigrations.php
+++ b/src/Package/Concerns/HasMigrations.php
@@ -3,8 +3,6 @@
 namespace Asciito\LaravelPackage\Package\Concerns;
 
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\File;
-use Symfony\Component\Finder\SplFileInfo;
 
 trait HasMigrations
 {
@@ -52,7 +50,7 @@ trait HasMigrations
     {
         $migrations = $this->loadMigrationsDefaultFolder();
 
-         return collect($this->migrations)
+        return collect($this->migrations)
             ->merge($migrations)
             ->filter(function (bool $_, string $migration) {
                 return ! in_array($migration, $this->excludedMigrations);

--- a/src/Package/Concerns/HasMigrations.php
+++ b/src/Package/Concerns/HasMigrations.php
@@ -25,7 +25,7 @@ trait HasMigrations
 
     private function shouldLoadDefaultMigrationsFolder(): bool
     {
-        return !$this->preventLoadDefaultMigrationFolder && $this->shouldIncludeMigrationsFromFolder;
+        return ! $this->preventLoadDefaultMigrationFolder && $this->shouldIncludeMigrationsFromFolder;
     }
 
     public function withMigrations(string|array $migration = [], bool $publish = true): static
@@ -58,14 +58,14 @@ trait HasMigrations
         return collect($this->migrations)
             ->merge($migrations)
             ->filter(function (bool $_, string $migration) {
-                return !in_array($migration, $this->excludedMigrations);
+                return ! in_array($migration, $this->excludedMigrations);
             })
             ->keys();
     }
 
     private function loadMigrationsDefaultFolder(): array
     {
-        if (!$this->shouldLoadDefaultMigrationsFolder()) {
+        if (! $this->shouldLoadDefaultMigrationsFolder()) {
             return [];
         }
 
@@ -84,7 +84,7 @@ trait HasMigrations
         return collect($this->migrations)
             ->merge($migrations)
             ->filter(function (bool $publish, string $migration) {
-                return $publish && !in_array($migration, [...$this->excludedMigrations, ...$this->unpublishedMigrations]);
+                return $publish && ! in_array($migration, [...$this->excludedMigrations, ...$this->unpublishedMigrations]);
             })
             ->keys();
     }

--- a/src/Package/Contracts/WithCommands.php
+++ b/src/Package/Contracts/WithCommands.php
@@ -14,6 +14,14 @@ interface WithCommands
     public function hasCommands(): bool;
 
     /**
+     * Prevent registering the default command folder
+     *
+     * Calling this method ensures that the command files in the default folder
+     * wouldn't be loaded automatically.
+     */
+    public function preventDefaultCommands(): static;
+
+    /**
      * Register the config file(s) for the package
      *
      * By calling this method this will try to load your
@@ -29,4 +37,9 @@ interface WithCommands
      * @return Collection The commands registered in the package
      */
     public function getRegisteredCommands(): Collection;
+
+    /**
+     * Un-register a previously registered command
+     */
+    public function unregisterCommand(string $fqcn): static;
 }

--- a/src/Package/Contracts/WithConfig.php
+++ b/src/Package/Contracts/WithConfig.php
@@ -57,4 +57,14 @@ interface WithConfig
      * Get the path to the configuration folder
      */
     public function getConfigPath(string $path = ''): string;
+
+    /**
+     * Un-register a previously registered config
+     */
+    public function unregisterConfig(string $path): static;
+
+    /**
+     * Un-publish a previously published config
+     */
+    public function unpublishConfig(string $path): static;
 }

--- a/src/Package/Contracts/WithMigrations.php
+++ b/src/Package/Contracts/WithMigrations.php
@@ -56,4 +56,14 @@ interface WithMigrations
      * Get the path to the migrations folder
      */
     public function getMigrationPath(string $path = ''): string;
+
+    /**
+     * Un-register a previously registered migration
+     */
+    public function unregisterMigration(string $path): static;
+
+    /**
+     * Un-publish a previously published migration
+     */
+    public function unpublishMigration(string $path): static;
 }

--- a/src/Package/Package.php
+++ b/src/Package/Package.php
@@ -9,7 +9,9 @@ use Asciito\LaravelPackage\Package\Contracts\WithCommands;
 use Asciito\LaravelPackage\Package\Contracts\WithConfig;
 use Asciito\LaravelPackage\Package\Contracts\WithMigrations;
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\File;
+use Symfony\Component\Finder\SplFileInfo;
 
 class Package implements WithCommands, WithConfig, WithMigrations
 {
@@ -85,6 +87,20 @@ class Package implements WithCommands, WithConfig, WithMigrations
         return join_paths($this->basePath, $path);
     }
 
+    /**
+     * Get the files from the given path
+     *
+     * @param string $path
+     * @param string|array $extensions The extension of the files you want to include
+     * @return Collection
+     */
+    protected function loadFilesFrom(string $path, string|array $extensions = 'php'): Collection
+    {
+        return collect(File::files($path))
+            ->filter(fn (SplFileInfo $file) => in_array($file->getExtension(), (array) $extensions))
+            ->mapWithKeys(fn (SplFileInfo $file) => [(string) $file => true]);
+    }
+
     public function setNamespace(string $namespace): static
     {
         $this->namespace = $namespace;
@@ -95,10 +111,5 @@ class Package implements WithCommands, WithConfig, WithMigrations
     public function getNamespace(): string
     {
         return $this->namespace;
-    }
-
-    protected function getFileName(string $file): string
-    {
-        return str_replace('.php', '', basename($file));
     }
 }

--- a/src/Package/Package.php
+++ b/src/Package/Package.php
@@ -90,9 +90,7 @@ class Package implements WithCommands, WithConfig, WithMigrations
     /**
      * Get the files from the given path
      *
-     * @param string $path
-     * @param string|array $extensions The extension of the files you want to include
-     * @return Collection
+     * @param  string|array  $extensions The extension of the files you want to include
      */
     protected function loadFilesFrom(string $path, string|array $extensions = 'php'): Collection
     {

--- a/src/Package/Package.php
+++ b/src/Package/Package.php
@@ -96,4 +96,9 @@ class Package implements WithCommands, WithConfig, WithMigrations
     {
         return $this->namespace;
     }
+
+    protected function getFileName(string $file): string
+    {
+        return str_replace('.php', '', basename($file));
+    }
 }

--- a/src/Package/Package.php
+++ b/src/Package/Package.php
@@ -17,15 +17,48 @@ class Package implements WithCommands, WithConfig, WithMigrations
 {
     use HasCommands, HasConfig, HasMigrations;
 
+    /**
+     * @var string The package name
+     */
     protected string $name;
 
+    /**
+     * @var string Base path for the package
+     */
     protected string $basePath;
 
+    /**
+     * @var string Package namespace
+     */
     protected string $namespace;
 
     /**
-     * The name of the package
+     * Set the package name
      *
+     * @param  string  $name  The package name
+     */
+    public function setName(string $name): static
+    {
+        $this->name = str($name)->slug();
+
+        return $this;
+    }
+
+    /**
+     * Prefix the given value string with the package name
+     * If the package name is the same as the given value, the same value is return
+     */
+    public function prefixWithPackageName(string $value, string $sep = '-'): string
+    {
+        if ($value === $this->name()) {
+            return $value;
+        }
+
+        return $this->name().$sep.$value;
+    }
+
+    /**
+     * The name of the package
      * If the name was not set, the name is guest by using your composer.json
      */
     public function name(): string
@@ -49,30 +82,9 @@ class Package implements WithCommands, WithConfig, WithMigrations
         return $this->name;
     }
 
-    /**
-     * Set the name of the package
-     *
-     * @param  string  $name The name of the package
-     */
-    public function setName(string $name): static
+    public function getBasePath(string $path = ''): string
     {
-        $this->name = str($name)->slug();
-
-        return $this;
-    }
-
-    /**
-     * Prefix the given value string with the package name
-     *
-     * If the package name is the same as the given value, the same value is return
-     */
-    public function prefixWithPackageName(string $value, string $sep = '-'): string
-    {
-        if ($value === $this->name()) {
-            return $value;
-        }
-
-        return $this->name().$sep.$value;
+        return join_paths($this->basePath, $path);
     }
 
     public function setBasePath(string $path): static
@@ -82,21 +94,9 @@ class Package implements WithCommands, WithConfig, WithMigrations
         return $this;
     }
 
-    public function getBasePath(string $path = ''): string
+    public function getNamespace(): string
     {
-        return join_paths($this->basePath, $path);
-    }
-
-    /**
-     * Get the files from the given path
-     *
-     * @param  string|array  $extensions The extension of the files you want to include
-     */
-    protected function loadFilesFrom(string $path, string|array $extensions = 'php'): Collection
-    {
-        return collect(File::files($path))
-            ->filter(fn (SplFileInfo $file) => in_array($file->getExtension(), (array) $extensions))
-            ->mapWithKeys(fn (SplFileInfo $file) => [(string) $file => true]);
+        return $this->namespace;
     }
 
     public function setNamespace(string $namespace): static
@@ -106,8 +106,15 @@ class Package implements WithCommands, WithConfig, WithMigrations
         return $this;
     }
 
-    public function getNamespace(): string
+    /**
+     * Get the files from the given path
+     *
+     * @param  string|array  $extensions  The file extension(s) you want to include
+     */
+    protected function loadFilesFrom(string $path, string|array $extensions = 'php'): Collection
     {
-        return $this->namespace;
+        return collect(File::files($path))
+            ->filter(fn (SplFileInfo $file) => in_array($file->getExtension(), (array) $extensions))
+            ->mapWithKeys(fn (SplFileInfo $file) => [(string) $file => true]);
     }
 }

--- a/src/Package/PackageServiceProvider.php
+++ b/src/Package/PackageServiceProvider.php
@@ -135,22 +135,16 @@ abstract class PackageServiceProvider extends ServiceProvider
         if ($package->hasMigrations()) {
             $this->publishes(
                 $package->getPublishableMigrations()
-                    ->mapWithKeys(function (string $migration, int|string $index) {
-                        if (preg_match('/^\d{4}_\d{2}_\d{2}_/', $migration)) {
-                            return $migration;
-                        }
+                    ->mapWithKeys(function (string $migration) {
+                        $databaseMigration = database_path('migrations/'.basename($migration));
 
-                        $date = Carbon::now()->format('Y_m_d');
-
-                        $index = str($index)->padLeft(6, '0');
-
-                        return [
-                            $migration => database_path('migrations/'.$date.'_'.$index.'_'.basename($migration)),
-                        ];
+                        return [$migration => $databaseMigration];
                     })
                     ->all(),
                 $package->prefixWithPackageName('migrations')
             );
+
+            $this->loadMigrationsFrom($package->getRegisteredMigrations()->all());
         }
     }
 

--- a/src/Package/PackageServiceProvider.php
+++ b/src/Package/PackageServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace Asciito\LaravelPackage\Package;
 
-use Carbon\Carbon;
 use Illuminate\Support\ServiceProvider;
 
 abstract class PackageServiceProvider extends ServiceProvider

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -11,3 +11,19 @@ if (! function_exists('join_paths')) {
         return rtrim(Arr::join($path, DIRECTORY_SEPARATOR), DIRECTORY_SEPARATOR);
     }
 }
+
+if (! function_exists('absolute')) {
+    /**
+     * Return the absolute path of the given path
+     *
+     * @returns false if the resulting path is not absolute
+     */
+    function absolute(string $path, string $absolutePath = null): string
+    {
+        if (! realpath($path)) {
+            return join_paths(rtrim($absolutePath ?? '', DIRECTORY_SEPARATOR), trim($path, DIRECTORY_SEPARATOR));
+        }
+
+        return $path;
+    }
+}

--- a/tests/Feature/NestedServiceProvider/RegisterConfigTest.php
+++ b/tests/Feature/NestedServiceProvider/RegisterConfigTest.php
@@ -5,7 +5,7 @@ use Asciito\LaravelPackage\Package\Package;
 use function Pest\Laravel\{ artisan };
 use function PHPUnit\Framework\assertFileExists;
 
-trait NestedServiceProviderWithConfig
+trait NestedServiceProviderConfig
 {
     protected function configureNestedService(Package $package): void
     {
@@ -24,7 +24,7 @@ trait NestedServiceProviderWithConfig
     }
 }
 
-uses(NestedServiceProviderWithConfig::class);
+uses(NestedServiceProviderConfig::class);
 
 it('register config', function () {
     expect(config('nested-one.key'))

--- a/tests/Feature/NestedServiceProvider/RegisterMigrationsTest.php
+++ b/tests/Feature/NestedServiceProvider/RegisterMigrationsTest.php
@@ -20,6 +20,7 @@ trait NestedServiceProviderWithMigrations
             ->toBe($package->getBasePath('../../database/migrations/nested'))
             ->getPublishableMigrations()
             ->not->toBeEmpty()
+            ->toHaveCount(2)
             ->each
             ->toStartWith($package->getMigrationPath())
             ->toMatch('/\/\w+.php$/');
@@ -28,15 +29,18 @@ trait NestedServiceProviderWithMigrations
 
 uses(NestedServiceProviderWithMigrations::class);
 
+it('register migrations', function () {
+    artisan('migrate')->run();
+
+    assertdatabasecount('nested_test_one', 0);
+    assertdatabasecount('nested_test_one', 0);
+});
+
 it('publish migrations', function () {
     artisan('vendor:publish', ['--tag' => 'nested-service-migrations'])->run();
 
-    assertFileExists(database_path('migrations/2023_01_01_000000_create_nested_test_one_table.php'));
-    assertFileExists(database_path('migrations/2023_01_01_000001_create_nested_test_two_table.php'));
-});
-
-it('run published migrations', function () {
-    artisan('vendor:publish', ['--tag' => 'nested-service-migrations'])->run();
+    assertFileExists(database_path('migrations/create_nested_test_one_table.php'));
+    assertFileExists(database_path('migrations/create_nested_test_two_table.php'));
 
     artisan('migrate')->assertSuccessful();
 

--- a/tests/Feature/Package/RegisterConfigTest.php
+++ b/tests/Feature/Package/RegisterConfigTest.php
@@ -3,24 +3,25 @@
 use Asciito\LaravelPackage\Package\Package;
 
 use function Pest\Laravel\{ artisan };
+use function PHPUnit\Framework\assertFileDoesNotExist;
 use function PHPUnit\Framework\assertFileExists;
 
-trait PackageWithConfig
+trait RegisterConfig
 {
     protected function configurePackage(Package $package): void
     {
         $package
-            ->setName('laravel-package')
-            ->preventDefaultConfig()
+            ->setName('register-configuration')
             ->withConfig([
                 $package->getConfigPath('one.php'),
                 $package->getConfigPath('two.php'),
-                $package->getConfigPath('extra/three.php'),
-            ]);
+            ])
+            ->withConfig($package->getConfigPath('extra/three.php'), false)
+            ->preventDefaultConfig();
     }
 }
 
-uses(PackageWithConfig::class);
+uses(RegisterConfig::class);
 
 it('register config', function () {
     expect(config('one.key'))
@@ -32,10 +33,9 @@ it('register config', function () {
 });
 
 it('publish config files', function () {
-    artisan('vendor:publish', ['--tag' => 'laravel-package-config'])
-        ->doesntExpectOutputToContain('No publishable resources for tag [laravel-package-config]')
-        ->assertSuccessful();
+    artisan('vendor:publish', ['--tag' => 'register-configuration-config'])->run();
 
     assertFileExists(config_path('one.php'));
     assertFileExists(config_path('two.php'));
+    assertFileDoesNotExist(config_path('three.php'));
 });

--- a/tests/Feature/Package/RegisterMigrationsTest.php
+++ b/tests/Feature/Package/RegisterMigrationsTest.php
@@ -2,6 +2,7 @@
 
 use Asciito\LaravelPackage\Package\Package;
 
+use Illuminate\Support\Facades\File;
 use function Pest\Laravel\artisan;
 use function Pest\Laravel\assertDatabaseCount;
 use function PHPUnit\Framework\assertFileExists;
@@ -11,33 +12,30 @@ trait PackageWithMigrations
     protected function configurePackage(Package $package): void
     {
         $package
-            ->preventDefaultMigrations()
-            ->withMigrations([
-                $package->getMigrationPath('create_package_test_one_table.php'),
-                $package->getMigrationPath('create_package_test_two_table.php'),
-                $package->getMigrationPath('create_package_test_three_table.php'),
-                $package->getMigrationPath('create_package_test_four_table.php'),
-            ]);
+            ->setName('test-package-migration')
+            ->withMigrations();
     }
 }
 
 uses(PackageWithMigrations::class);
 
-it('publish migrations', function () {
-    artisan('vendor:publish', ['--tag' => 'test-package-migrations'])
-        ->doesntExpectOutputToContain('No publishable resources for tag [test-package-migration]')
-        ->assertSuccessful();
+it('register migrations', function () {
+    artisan('migrate')->run();
 
-    assertFileExists(database_path('migrations/2023_01_01_000000_create_package_test_one_table.php'));
-    assertFileExists(database_path('migrations/2023_01_01_000001_create_package_test_two_table.php'));
-    assertFileExists(database_path('migrations/2023_01_01_000002_create_package_test_three_table.php'));
-    assertFileExists(database_path('migrations/2023_01_01_000003_create_package_test_four_table.php'));
+    assertdatabasecount('package_test_one', 0);
+    assertdatabasecount('package_test_two', 0);
+    assertdatabasecount('package_test_three', 0);
+    assertdatabasecount('package_test_four', 0);
 });
 
-it('run published migrations', function () {
-    artisan('vendor:publish', ['--tag' => 'test-package-migrations'])
-        ->doesntExpectOutputToContain('No publishable resources for tag [test-package-migration]')
+it('published migrations', function () {
+    artisan('vendor:publish', ['--tag' => 'test-package-migration-migrations'])
         ->assertSuccessful();
+
+    assertFileExists(database_path('migrations/create_package_test_one_table.php'));
+    assertFileExists(database_path('migrations/create_package_test_two_table.php'));
+    assertFileExists(database_path('migrations/create_package_test_three_table.php'));
+    assertFileExists(database_path('migrations/create_package_test_four_table.php'));
 
     artisan('migrate')->assertSuccessful();
 

--- a/tests/Feature/Package/RegisterMigrationsTest.php
+++ b/tests/Feature/Package/RegisterMigrationsTest.php
@@ -2,7 +2,6 @@
 
 use Asciito\LaravelPackage\Package\Package;
 
-use Illuminate\Support\Facades\File;
 use function Pest\Laravel\artisan;
 use function Pest\Laravel\assertDatabaseCount;
 use function PHPUnit\Framework\assertFileExists;

--- a/tests/Feature/Package/UnregisterCommandsTest.php
+++ b/tests/Feature/Package/UnregisterCommandsTest.php
@@ -4,6 +4,7 @@ use Asciito\LaravelPackage\Package\Package;
 use Symfony\Component\Console\Exception\CommandNotFoundException;
 use Workbench\App\Console\Commands\Extras\PackageTestCommandTwo;
 use Workbench\App\Console\Commands\PackageTestCommandOne;
+
 use function Pest\Laravel\{artisan};
 
 trait UnregisterPackageCommand

--- a/tests/Feature/Package/UnregisterCommandsTest.php
+++ b/tests/Feature/Package/UnregisterCommandsTest.php
@@ -1,0 +1,34 @@
+<?php
+
+use Asciito\LaravelPackage\Package\Package;
+use Symfony\Component\Console\Exception\CommandNotFoundException;
+use Workbench\App\Console\Commands\Extras\PackageTestCommandTwo;
+use Workbench\App\Console\Commands\PackageTestCommandOne;
+use function Pest\Laravel\{artisan};
+
+trait UnregisterPackageCommand
+{
+    protected function configurePackage(Package $package): void
+    {
+        $package
+            ->withCommands(PackageTestCommandTwo::class)
+            ->unregisterCommand(PackageTestCommandOne::class);
+    }
+}
+
+uses(UnregisterPackageCommand::class);
+
+it('register commands', function () {
+    artisan('list')
+        ->expectsOutputToContain('package:two')
+        ->doesntExpectOutputToContain('package:one')
+        ->assertSuccessful();
+});
+
+it('run commands', function () {
+    artisan('package:two')
+        ->expectsOutput('Package command two')
+        ->assertSuccessful();
+
+    artisan('package:one')->run();
+})->throws(CommandNotFoundException::class);

--- a/tests/Feature/Package/UnregisterConfigTest.php
+++ b/tests/Feature/Package/UnregisterConfigTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Asciito\LaravelPackage\Tests\Feature\Package;
+
+use Asciito\LaravelPackage\Package\Package;
+use function Pest\Laravel\artisan;
+use function PHPUnit\Framework\assertFileDoesNotExist;
+
+trait
+UnregisterConfigTest
+{
+    protected function configurePackage(Package $package): void
+    {
+        $package
+            ->setName('unregister')
+            ->withConfig($package->getConfigPath('extra/three.php'))
+            ->unregisterConfig($package->getConfigPath('one.php'))
+            ->unpublishConfig($package->getConfigPath('extra/three.php'));
+    }
+}
+
+uses(UnregisterConfigTest::class);
+
+test('un-register config', function () {
+    artisan('vendor:publish', ['--tag' => 'unregister-config'])->run();
+
+    expect(config('one.key'))
+        ->toBeNull();
+
+    assertFileDoesNotExist(config_path('one.php'));
+});
+
+test('un-publish config', function () {
+    artisan('vendor:publish', ['--tag' => 'unregister-config'])->run();
+
+    expect(config('three.key'))
+        ->toBe('three');
+
+    assertFileDoesNotExist(config_path('three.key'));
+});

--- a/tests/Feature/Package/UnregisterConfigTest.php
+++ b/tests/Feature/Package/UnregisterConfigTest.php
@@ -3,11 +3,11 @@
 namespace Asciito\LaravelPackage\Tests\Feature\Package;
 
 use Asciito\LaravelPackage\Package\Package;
+
 use function Pest\Laravel\artisan;
 use function PHPUnit\Framework\assertFileDoesNotExist;
 
-trait
-UnregisterConfigTest
+trait UnregisterConfigTest
 {
     protected function configurePackage(Package $package): void
     {

--- a/tests/Feature/Package/UnregisterConfigTest.php
+++ b/tests/Feature/Package/UnregisterConfigTest.php
@@ -7,22 +7,22 @@ use Asciito\LaravelPackage\Package\Package;
 use function Pest\Laravel\artisan;
 use function PHPUnit\Framework\assertFileDoesNotExist;
 
-trait UnregisterConfigTest
+trait UnregisterConfig
 {
     protected function configurePackage(Package $package): void
     {
         $package
-            ->setName('unregister')
+            ->setName('unregistered-unpublished-configuration')
             ->withConfig($package->getConfigPath('extra/three.php'))
-            ->unregisterConfig($package->getConfigPath('one.php'))
-            ->unpublishConfig($package->getConfigPath('extra/three.php'));
+            ->unregisterConfig('one.php')
+            ->unpublishConfig('three.php');
     }
 }
 
-uses(UnregisterConfigTest::class);
+uses(UnregisterConfig::class);
 
 test('un-register config', function () {
-    artisan('vendor:publish', ['--tag' => 'unregister-config'])->run();
+    artisan('vendor:publish', ['--tag' => 'unregistered-unpublished-configuration-config'])->run();
 
     expect(config('one.key'))
         ->toBeNull();
@@ -31,10 +31,10 @@ test('un-register config', function () {
 });
 
 test('un-publish config', function () {
-    artisan('vendor:publish', ['--tag' => 'unregister-config'])->run();
+    artisan('vendor:publish', ['--tag' => 'unregistered-unpublished-configuration-config'])->run();
+
+    assertFileDoesNotExist(config_path('three.key'));
 
     expect(config('three.key'))
         ->toBe('three');
-
-    assertFileDoesNotExist(config_path('three.key'));
 });

--- a/tests/Feature/Package/UnregisterMigrationTest.php
+++ b/tests/Feature/Package/UnregisterMigrationTest.php
@@ -4,12 +4,12 @@ namespace Asciito\LaravelPackage\Tests\Feature\Package;
 
 use Asciito\LaravelPackage\Package\Package;
 use Illuminate\Database\QueryException;
+
 use function Pest\Laravel\artisan;
 use function Pest\Laravel\assertDatabaseCount;
 use function PHPUnit\Framework\assertFileDoesNotExist;
 
-trait
-UnregisterMigrationTest
+trait UnregisterMigrationTest
 {
     protected function configurePackage(Package $package): void
     {

--- a/tests/Feature/Package/UnregisterMigrationTest.php
+++ b/tests/Feature/Package/UnregisterMigrationTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Asciito\LaravelPackage\Tests\Feature\Package;
+
+use Asciito\LaravelPackage\Package\Package;
+use Illuminate\Database\QueryException;
+use function Pest\Laravel\artisan;
+use function Pest\Laravel\assertDatabaseCount;
+use function PHPUnit\Framework\assertFileDoesNotExist;
+
+trait
+UnregisterMigrationTest
+{
+    protected function configurePackage(Package $package): void
+    {
+        $package
+            ->setName('unregister-migration')
+            ->withMigrations()
+            ->unregisterMigration('create_package_test_one_table.php')
+            ->unpublishMigration('create_package_test_two_table.php');
+    }
+}
+
+uses(UnregisterMigrationTest::class);
+
+test('un-register migrations', function () {
+    artisan('migrate')->run();
+
+    // Will throw and error if the database not exist.
+    assertDatabaseCount('package_test_one', 0);
+})->throws(QueryException::class);
+
+test('un-publish migration', function () {
+    artisan('vendor:publish', ['--tag' => 'unregister-migration-migrations'])->run();
+
+    assertFileDoesNotExist(database_path('migrations/create_package_test_one_table.php'));
+    assertFileDoesNotExist(database_path('migrations/create_package_test_two_table.php'));
+
+    artisan('migrate')->run();
+
+    assertDatabaseCount('package_test_two', 0);
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -11,9 +11,10 @@
 |
 */
 
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Workbench\Tests\ServiceProviderTest;
 
-uses(ServiceProviderTest::class)->in('Feature');
+uses(ServiceProviderTest::class, RefreshDatabase::class)->in('Feature');
 
 /*
 |--------------------------------------------------------------------------

--- a/tests/Unit/TestHelpers.php
+++ b/tests/Unit/TestHelpers.php
@@ -2,7 +2,7 @@
 
 dataset('paths', [
     ['join', 'a', 'path', 'join/a/path'],
-    ['/this', 'is', '../weird/', '/this/is/../weird']
+    ['/this', 'is', '../weird/', '/this/is/../weird'],
 ]);
 
 it('join paths', function (string ...$data) {

--- a/tests/Unit/TestHelpers.php
+++ b/tests/Unit/TestHelpers.php
@@ -1,0 +1,19 @@
+<?php
+
+dataset('paths', [
+    ['join', 'a', 'path', 'join/a/path'],
+    ['/this', 'is', '../weird/', '/this/is/../weird']
+]);
+
+it('join paths', function (string ...$data) {
+    expect(join_paths($data[0], $data[1], $data[2]))
+        ->toBe($data[3]);
+})
+    ->with('paths');
+
+it('return absolute path', function () {
+    $configFolder = join_paths(__DIR__, '..', '..', 'workbench', 'config');
+
+    expect(absolute('one.php', $configFolder))
+        ->toBe(join_paths($configFolder, 'one.php'));
+});

--- a/workbench/app/Nested/NestedServiceProvider.php
+++ b/workbench/app/Nested/NestedServiceProvider.php
@@ -15,9 +15,4 @@ class NestedServiceProvider extends PackageServiceProvider
 
         $configClosure($package);
     }
-
-    protected function getNamespace(): string
-    {
-        return __NAMESPACE__;
-    }
 }

--- a/workbench/app/ServiceProvider.php
+++ b/workbench/app/ServiceProvider.php
@@ -15,9 +15,4 @@ class ServiceProvider extends PackageServiceProvider
 
         $configClosure($package);
     }
-
-    protected function getNamespace(): string
-    {
-        return __NAMESPACE__;
-    }
 }

--- a/workbench/tests/ServiceProviderTest.php
+++ b/workbench/tests/ServiceProviderTest.php
@@ -5,6 +5,7 @@ namespace Workbench\Tests;
 use Asciito\LaravelPackage\Package\Package;
 use Asciito\LaravelPackage\Tests\TestCase;
 use Illuminate\Support\Facades\File;
+use Symfony\Component\Finder\SplFileInfo;
 use Workbench\App\Nested\NestedServiceProvider;
 use Workbench\App\ServiceProvider;
 
@@ -16,6 +17,8 @@ abstract class ServiceProviderTest extends TestCase
         'one.php',
         'two.php',
         'three.php',
+        'nested-one.php',
+        'nested-two.php',
     ];
 
     protected function setUp(): void
@@ -64,6 +67,8 @@ abstract class ServiceProviderTest extends TestCase
                 ->all()
         );
 
-        File::cleanDirectory(database_path('migrations'));
+        collect(File::files(database_path('migrations')))
+            ->filter(fn (SplFileInfo $file) => $file->getExtension() === '.php')
+            ->each(fn (SplFileInfo $file) => File::delete($file));
     }
 }

--- a/workbench/tests/ServiceProviderTest.php
+++ b/workbench/tests/ServiceProviderTest.php
@@ -68,7 +68,7 @@ abstract class ServiceProviderTest extends TestCase
         );
 
         collect(File::files(database_path('migrations')))
-            ->filter(fn (SplFileInfo $file) => $file->getExtension() === '.php')
+            ->filter(fn (SplFileInfo $file) => $file->getExtension() === 'php')
             ->each(fn (SplFileInfo $file) => File::delete($file));
     }
 }


### PR DESCRIPTION
This PR adds the ability to unregister/unpublish a file, keep in mind that if you choose to call the actions to ```unregister``` a file,  this will be also forbidden from being publishable, just the ```unpublish``` actions let you register the file in the package. For example, a config file can be used in the package by calling the ```config()``` if you choose to just ```unpublish``` the file, but you cannot publish this file in the config folder, so the client can't use/edit the file.
